### PR TITLE
Add ability to hide reference button in paired comparison page.

### DIFF
--- a/lib/webmushra/pages/PairedComparisonPage.js
+++ b/lib/webmushra/pages/PairedComparisonPage.js
@@ -145,6 +145,11 @@ PairedComparisonPage.prototype.render = function (_parent) {
   trPlays.append(buttonPlayB);
   
 
+  if (this.pageConfig['hideReference']) {
+    buttonPlayReference.css('visibility', 'hidden');
+    $(trNames.children()[0]).css('visibility', 'hidden');
+  }
+
   var trQuestion = $("<tr><td  colspan='3'><br/><br/>" + this.pageManager.getLocalizer().getFragment(this.language, 'quest') + "</td></tr>");
   tableAB.append(trQuestion);
 


### PR DESCRIPTION
The typical PairedComparisonPage shows three buttons: the reference button, the A button, and the B button. The UI allows the user to choose A or B, assuming one of those sources matches the reference source. This is not exactly an A/B test that allows the user to choose which source they prefer.

In order to make this format work for a A/B test, we'll make it possible to hide the reference audio and button. If the reference is hidden, then we can always put the attenuated audio in the reference audio, and use the "correct" boolean provided in the results to determine which audio the user prefers.

So this PR adds the option `hideReference: true` to the yaml file for the PairedComparisonPage, and if so, it hides the button.