### PR TITLE
Allow multiple Likert scales per stimulus and require playback to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ doc/jsdoc
 .project
 dist
 builds/
+results/*
+!results/results_will_be_added_here.txt
 
 #####=== Node ===#####
 

--- a/configs/LMS_4scale.yaml
+++ b/configs/LMS_4scale.yaml
@@ -18,6 +18,8 @@ pages:
       content: test description
       stimuli:
           C1: configs/resources/audio/mono_c1.wav
+          C2: configs/resources/audio/mono_c2.wav
+          C3: configs/resources/audio/mono_c3.wav
       response:
         - value: not at all
           label: Not at all

--- a/configs/LSS_multiscale.yaml
+++ b/configs/LSS_multiscale.yaml
@@ -16,6 +16,7 @@ pages:
       id: lss3
       name: likert
       content: Two out of three stimuli will be randomly selected. In order to select the first two, set randomize to false in the config file.
+      showWaveform: true
       mustPlayback: ended
       mustRate: true
       randomize: true

--- a/configs/LSS_multiscale.yaml
+++ b/configs/LSS_multiscale.yaml
@@ -15,9 +15,11 @@ pages:
     - type: likert_single_stimulus
       id: lss3
       name: likert
-      content: test description
+      content: Two out of three stimuli will be randomly selected. In order to select the first two, set randomize to false in the config file.
       mustPlayback: ended
       mustRate: true
+      randomize: true
+      maxStimuli: 2
       stimuli:
           C1: configs/resources/audio/mono_c1.wav
           C2: configs/resources/audio/mono_c2.wav

--- a/configs/LSS_multiscale.yaml
+++ b/configs/LSS_multiscale.yaml
@@ -1,0 +1,65 @@
+# Likert single stimulus page 1 stimulus, two Likert scales with respecitvely 4 and 2 responses
+
+
+testname: Single Stimulus with multiple Likert scales
+testId: lss_multiscale
+bufferSize: 2048
+stopOnErrors: true
+showButtonPreviousPage: true
+remoteService: service/write.php
+
+
+
+pages:
+
+    - type: likert_single_stimulus
+      id: lss3
+      name: likert
+      content: test description
+      mustPlayback: ended
+      mustRate: true
+      stimuli:
+          C1: configs/resources/audio/mono_c1.wav
+          C2: configs/resources/audio/mono_c2.wav
+          C3: configs/resources/audio/mono_c3.wav
+      response:
+        -
+          - value: not at all
+            label: Not at all
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png
+          - value: not a lot
+            label: Not a lot
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png
+          - value: a bit
+            label: A bit
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png
+          - value: much
+            label: Much
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png    
+        -
+          - value: not at all
+            label: Not at all
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png
+          - value: not a lot
+            label: Not a lot
+            img: configs/resources/images/star_off.png
+            imgSelected: configs/resources/images/star_on.png
+            imgHigherResponseSelected: configs/resources/images/star_on.png
+
+
+
+    - type: finish
+      name: Thank you
+      content: Thank you for attending
+      showResults: true
+      writeResults: true

--- a/configs/mushra_customquestionaire.yaml
+++ b/configs/mushra_customquestionaire.yaml
@@ -29,7 +29,7 @@ pages:
     - type: finish
       name: Thank you
       content: Thank you for attending
-      popupcontent: Your results were sent. Goodbye and have a nice day
+      popupContent: Your results were sent. Goodbye and have a nice day
       showResults: true
       writeResults: true
       questionnaire:

--- a/configs/mushra_noloop.yaml
+++ b/configs/mushra_noloop.yaml
@@ -37,6 +37,6 @@ pages:
     - type: finish
       name: Thank you
       content: Thank you for attending
-      popupcontent: Your results were sent. Goodbye and have a nice day
+      popupContent: Your results were sent. Goodbye and have a nice day
       showResults: true
       writeResults: true

--- a/configs/mushra_noloop_nowav.yaml
+++ b/configs/mushra_noloop_nowav.yaml
@@ -29,6 +29,6 @@ pages:
     - type: finish
       name: Thank you
       content: Thank you for attending
-      popupcontent: Your results were sent. Goodbye and have a nice day
+      popupContent: Your results were sent. Goodbye and have a nice day
       showResults: true
       writeResults: true

--- a/configs/mushra_norandom.yaml
+++ b/configs/mushra_norandom.yaml
@@ -47,6 +47,6 @@ pages:
     - type: finish
       name: Thank you
       content: Thank you for attending
-      popupcontent: Your results were sent. Goodbye and have a nice day      
+      popupContent: Your results were sent. Goodbye and have a nice day      
       showResults: true
       writeResults: true

--- a/configs/mushra_nowav.yaml
+++ b/configs/mushra_nowav.yaml
@@ -29,6 +29,6 @@ pages:
     - type: finish
       name: Thank you
       content: Thank you for attending
-      popupcontent: Your results were sent. Goodbye and have a nice day
+      popupContent: Your results were sent. Goodbye and have a nice day
       showResults: true
       writeResults: true

--- a/doc/experimenter.md
+++ b/doc/experimenter.md
@@ -103,6 +103,7 @@ A likert multi stimulus page creates a multi-stimulus likert rating.
 * **type** must be likert_multi_stimulus.
 * **id** Identifier of the page.
 * **name** Name of the page (is shown as title)
+* **content** Content (HTML) of the page. The content is shown on the upper part of the page.
 * **mustRate** If set to true, the participant must rate all stimuli.
 * **mustPlayback** If set to `ended`, the participant must fully play back all stimuli to the end. If set to `processUpdate`, the participant must start playing back all stimuli before rating becomes possible.
 * **stimuli** A map of stimuli which will all be presented on the same page. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
@@ -115,6 +116,8 @@ A likert single stimulus page creates a single-stimulus likert rating.
 * **type** must be likert_single_stimulus.
 * **id** Identifier of the page.
 * **name** Name of the page (is shown as title)
+* **content** Content (HTML) of the page. The content is shown on the upper part of the page.
+* **showWaveform** If set to true, the waveform of the stimulus is shown. 
 * **mustRate** If set to true, the participant must rate all stimuli.
 * **mustPlayback** If set to `ended`, the participant must fully play back the stimulus to the end. If set to `processUpdate`, the participant must start it before rating becomes possible.
 * **stimuli** A map of stimuli, each of which will be presented on a separate page. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).

--- a/doc/experimenter.md
+++ b/doc/experimenter.md
@@ -104,7 +104,7 @@ A likert multi stimulus page creates a multi-stimulus likert rating.
 * **id** Identifier of the page.
 * **name** Name of the page (is shown as title)
 * **mustRate** If set to true, the participant must rate all stimuli.
-* **mustPlayback** If set to true, the participant must fully play back all stimuli. 
+* **mustPlayback** If set to `ended`, the participant must fully play back all stimuli to the end. If set to `processUpdate`, the participant must start playing back all stimuli before rating becomes possible.
 * **reference** Filepath to the reference stimulus (WAV file).
 * **stimuli** A map of stimuli representing three conditions. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
 * **response** A array which represents the Likert scale, where each array element represents a 'likert point'. The array elements are maps with the keys 'value' (value shown in results), 'label' (label of the likert point), 'img' (path to an image of the likert point), 'imgSelected' (image shown if likert point is selected), and 'imgHigherResponseSelected' (image shown when a 'higher' likert point is selected).  
@@ -116,7 +116,8 @@ A likert single stimulus page creates a single-stimulus likert rating.
 * **type** must be likert_single_stimulus.
 * **id** Identifier of the page.
 * **name** Name of the page (is shown as title)
-* **mustRate** If set to true, the participant must rate all stimuli. 
+* **mustRate** If set to true, the participant must rate all stimuli.
+* **mustPlayback** If set to `ended`, the participant must fully play back the stimulus to the end. If set to `processUpdate`, the participant must start it before rating becomes possible.
 * **reference** Filepath to the reference stimulus (WAV file).
 * **stimuli** A map of stimuli representing three conditions. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
 * **response** An array which represents the Likert scale, where each array element represents a 'likert point'. The array elements are maps with the keys 'value' (value shown in results), 'label' (label of the likert point), 'img' (path to an image of the likert point), 'imgSelected' (image shown if likert point is selected), and 'imgHigherResponseSelected' (image shown when a 'higher' likert point is selected).  

--- a/doc/experimenter.md
+++ b/doc/experimenter.md
@@ -118,6 +118,7 @@ A likert single stimulus page creates a single-stimulus likert rating.
 * **mustRate** If set to true, the participant must rate all stimuli.
 * **mustPlayback** If set to `ended`, the participant must fully play back the stimulus to the end. If set to `processUpdate`, the participant must start it before rating becomes possible.
 * **stimuli** A map of stimuli, each of which will be presented on a separate page. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
+* **maxStimuli** An upper limit on the amount of stimuli presented to the user.
 * **response** An array which represents the Likert scale, where each array element represents a 'likert point'. The array elements are maps with the keys 'value' (value shown in results), 'label' (label of the likert point), 'img' (path to an image of the likert point), 'imgSelected' (image shown if likert point is selected), and 'imgHigherResponseSelected' (image shown when a 'higher' likert point is selected).  
 
 #### `finish` page

--- a/doc/experimenter.md
+++ b/doc/experimenter.md
@@ -105,8 +105,7 @@ A likert multi stimulus page creates a multi-stimulus likert rating.
 * **name** Name of the page (is shown as title)
 * **mustRate** If set to true, the participant must rate all stimuli.
 * **mustPlayback** If set to `ended`, the participant must fully play back all stimuli to the end. If set to `processUpdate`, the participant must start playing back all stimuli before rating becomes possible.
-* **reference** Filepath to the reference stimulus (WAV file).
-* **stimuli** A map of stimuli representing three conditions. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
+* **stimuli** A map of stimuli which will all be presented on the same page. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
 * **response** A array which represents the Likert scale, where each array element represents a 'likert point'. The array elements are maps with the keys 'value' (value shown in results), 'label' (label of the likert point), 'img' (path to an image of the likert point), 'imgSelected' (image shown if likert point is selected), and 'imgHigherResponseSelected' (image shown when a 'higher' likert point is selected).  
 
 #### `likert_single_stimulus` page
@@ -118,8 +117,7 @@ A likert single stimulus page creates a single-stimulus likert rating.
 * **name** Name of the page (is shown as title)
 * **mustRate** If set to true, the participant must rate all stimuli.
 * **mustPlayback** If set to `ended`, the participant must fully play back the stimulus to the end. If set to `processUpdate`, the participant must start it before rating becomes possible.
-* **reference** Filepath to the reference stimulus (WAV file).
-* **stimuli** A map of stimuli representing three conditions. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
+* **stimuli** A map of stimuli, each of which will be presented on a separate page. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).
 * **response** An array which represents the Likert scale, where each array element represents a 'likert point'. The array elements are maps with the keys 'value' (value shown in results), 'label' (label of the likert point), 'img' (path to an image of the likert point), 'imgSelected' (image shown if likert point is selected), and 'imgHigherResponseSelected' (image shown when a 'higher' likert point is selected).  
 
 #### `finish` page

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ https://www.audiolabs-erlangen.de/resources/webMUSHRA. Any unauthorised use
 of this source code may result in severe civil and criminal penalties, and
 will be prosecuted to the maximum extent possible under law.
 -->
-	<head>
+  <head>
 
 
     <meta charset="utf-8">
@@ -130,32 +130,32 @@ will be prosecuted to the maximum extent possible under law.
 
     <div class="header" id="header"></div>
 
-	<div id="container">
+    <div id="container">
 
-    <div id = "page_progressbar"></div>
-    <h3 class="ui-bar ui-bar-a ui-corner-all" id="page_header"></h3>
-    <div class="ui-body ui-body-a ui-corner-all" id="page_content">
-    </div>
-    <br/>
-    <div class="ui-body ui-body-a ui-corner-all" id="page_navigation">
-    </div>
+      <div id = "page_progressbar"></div>
+      <h3 class="ui-bar ui-bar-a ui-corner-all" id="page_header"></h3>
+      <div class="ui-body ui-body-a ui-corner-all" id="page_content">
+      </div>
+      <br/>
+      <div class="ui-body ui-body-a ui-corner-all" id="page_navigation">
+      </div>
 
-    <table align="right" class="logo">
-      <tr>
-        <td class="logo" style="vertical-align:top; padding-right:0px;"><small><strong>webMUSHRA
-            <!-- build:template:dev
-            Dev
-            /build -->
-            <!-- build:template
-            <%= version %>
-            /build -->
-            by</strong></small>
-        </td>
-        <td class="logo"><a href="https://www.audiolabs-erlangen.de/"><img src="design/images/alabs_new.png" class="logo"/></a></td>
-        <td class="logo"><a href="http://www.iis.fraunhofer.de/"><img src="design/images/iis.svg" class="logo" /></a></td>
-        <td class="logo"><a href="https://www.fau.eu/"><img src="design/images/techfak.svg" class="logo" /></a></td>
-      </tr>
-    </table>
+      <table align="right" class="logo">
+        <tr>
+          <td class="logo" style="vertical-align:top; padding-right:0px;"><small><strong>webMUSHRA
+              <!-- build:template:dev
+              Dev
+              /build -->
+              <!-- build:template
+              <%= version %>
+              /build -->
+              by</strong></small>
+          </td>
+          <td class="logo"><a href="https://www.audiolabs-erlangen.de/"><img src="design/images/alabs_new.png" class="logo"/></a></td>
+          <td class="logo"><a href="http://www.iis.fraunhofer.de/"><img src="design/images/iis.svg" class="logo" /></a></td>
+          <td class="logo"><a href="https://www.fau.eu/"><img src="design/images/techfak.svg" class="logo" /></a></td>
+        </tr>
+      </table>
 
     </div>
     <div data-role="popup" data-dismissible="false" data-history="false" data-transition="flip" positionTo="window" id="popupErrors">
@@ -166,9 +166,9 @@ will be prosecuted to the maximum extent possible under law.
       <div data-role="header" class="ui-corner-top"  style="width : 57.5em; background-color: #FFb500;">
         <h1 id="popHeader"></h1>
       </div>
-    <div id="popupResultsContent" style="background-color: white;" class="ui-corner-bottom ui-content">
+      <div id="popupResultsContent" style="background-color: white;" class="ui-corner-bottom ui-content">
+      </div>
     </div>
-	</div>
     <!-- build:js:generic startup.min.js -->
     <script src="startup.js"></script>
     <!-- /build -->

--- a/lib/webmushra/audio/GenericAudioControl.js
+++ b/lib/webmushra/audio/GenericAudioControl.js
@@ -262,3 +262,19 @@ GenericAudioControl.prototype.process = function(audioProcessingEvent) {
   this.audioCommand = null;
   
 };
+
+GenericAudioControl.prototype.setPosition = function(_position, _setStartEnd) {
+  var index = this.audioStimulusIndex;
+  if (index == null) {
+    index = 0;
+  }
+  this.audioCurrentPositions[index] = _position;
+  var eventUpdate = {
+    name: 'processUpdate',
+    currentSample: this.audioCurrentPositions[index],
+    numSamples: this.audioMaxPositions[index],
+    index: index
+    // sampleRate: this.audioSampleRate
+  };  
+  this.sendEvent(eventUpdate);  
+};

--- a/lib/webmushra/misc/FilePlayer.js
+++ b/lib/webmushra/misc/FilePlayer.js
@@ -5,7 +5,7 @@ This source code is protected by copyright law and international treaties. This 
 
 **************************************************************************/
 
-function FilePlayer(_audioContext, _bufferSize, _stimuli, _errorHandler, _language, _localizer) {
+function FilePlayer(_audioContext, _bufferSize, _stimuli, _errorHandler, _language, _localizer, _hideProgressBar) {
   this.audioContext = _audioContext;
   this.bufferSize = _bufferSize;
   this.stimuli = _stimuli;  
@@ -14,6 +14,7 @@ function FilePlayer(_audioContext, _bufferSize, _stimuli, _errorHandler, _langua
   this.localizer = _localizer;
   this.genericAudioControl = new GenericAudioControl(this.audioContext, this.bufferSize, this.stimuli, this.errorHandler);
   this.progressBars = [];
+  this.hideProgressBar = _hideProgressBar;
   
   this.genericAudioControl.addEventListener((function (_event) {
     if (_event.name == 'processUpdate') {
@@ -27,9 +28,11 @@ function FilePlayer(_audioContext, _bufferSize, _stimuli, _errorHandler, _langua
 
 FilePlayer.prototype.init = function() {
   this.genericAudioControl.initAudio();
-  for (var i = 0; i < this.stimuli.length; ++i) {
-    TolitoProgressBar(this.progressBars[i].attr('id')).setOuterTheme('a').setInnerTheme('b').isMini(true).setMax(100).setStartFrom(0).setInterval(0).showCounter(false).build();
-  }      
+  if (this.hideProgressBar != true) {
+    for (var i = 0; i < this.stimuli.length; ++i) {
+      TolitoProgressBar(this.progressBars[i].attr('id')).setOuterTheme('a').setInnerTheme('b').isMini(true).setMax(100).setStartFrom(0).setInterval(0).showCounter(false).build();
+    }
+  }
 };
 
 FilePlayer.prototype.free = function() {
@@ -43,29 +46,31 @@ FilePlayer.prototype.load = function() {
 
 FilePlayer.prototype.renderElement = function(_parent, _i) {
   var buttonPlay = $('<button data-role="button" id="playCondition'+_i+'" name="'+_i+'">' + this.localizer.getFragment(this.language, 'playButton')  + '</button>');
-    buttonPlay.bind( "click", (function(event, ui) {
-      this.genericAudioControl.play(parseInt(event.target.name));
-    }).bind(this));
+  buttonPlay.bind( "click", (function(event, ui) {
+    this.genericAudioControl.play(parseInt(event.target.name));
+  }).bind(this));
     
-    var buttonPause = $('<button data-role="button" id="pause">' + this.localizer.getFragment(this.language, 'pauseButton')  + '</button>');
-    buttonPause.bind( "click", (function(event, ui) {
-      this.genericAudioControl.pause();
-    }).bind(this));
-    
+  var buttonPause = $('<button data-role="button" id="pause">' + this.localizer.getFragment(this.language, 'pauseButton')  + '</button>');
+  buttonPause.bind( "click", (function(event, ui) {
+    this.genericAudioControl.pause();
+  }).bind(this));
+  
+  if (this.hideProgressBar != true) {
     var id = "FilePlayer_progressbar_" + _i;
     var progressBar = $('<div id = "' + id + '" class="fileplayer_progressbar" ></div>');
     this.progressBars[_i] = progressBar;
-    this.hooks[_i] = $('<td></td>');    
-    _parent.append(
-      $('<table></table>').append(
-        $('<tr></tr>').append(
-          $('<td></td>').append(buttonPlay), 
-          $('<td></td>').append(buttonPause),
-          $('<td></td>').append(progressBar),
-          this.hooks[_i]
-        )
+  }
+  this.hooks[_i] = $('<td></td>');    
+  _parent.append(
+    $('<table></table>').append(
+      $('<tr></tr>').append(
+        $('<td></td>').append(buttonPlay), 
+        $('<td></td>').append(buttonPause),
+        $('<td></td>').append(progressBar),
+        this.hooks[_i]
       )
-    );
+    )
+  );
 };
 
 FilePlayer.prototype.render = function(_parent) {

--- a/lib/webmushra/misc/LikertScale.js
+++ b/lib/webmushra/misc/LikertScale.js
@@ -27,41 +27,41 @@ LikertScale.prototype.render = function (_parent) {
   this.elements = [];
   var i;
   if(this.responseConfig != null){
-  for (i = 0; i < this.responseConfig.length; ++i) {
-    var responseValueConfig = this.responseConfig[i];
-    var img = "";
-    if (responseValueConfig.img) {
-      img = "<img id='"+this.prefix+"_response_img_"+i+"' src='"+responseValueConfig.img+"'/><br/>";
-    }
-    var element = $("<input type='radio' data-mini='false' value='"+responseValueConfig.value+"' name='"+this.prefix+"_response' id='"+this.prefix+"_response_"+i+"'/> \
-      <label for='"+this.prefix+"_response_"+i+"'><center>"+img+""+responseValueConfig.label+"</center></label> \
-    ");
-    this.elements[this.elements.length] = element;
-    this.group.append(element);
-  }
-  
-  this.group.change((function() {
-
-  var set = false;
-  for (i = 0; i < this.elements.length; ++i) {    
-    if (set === true) {
-      $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].img);
-    } else {
-      if ($("#"+this.prefix+"_response_"+i+":checked").val()) {
-        set = true;
-        $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].imgSelected);
-      } else {
-        $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].imgHigherResponseSelected);
+    for (i = 0; i < this.responseConfig.length; ++i) {
+      var responseValueConfig = this.responseConfig[i];
+      var img = "";
+      if (responseValueConfig.img) {
+        img = "<img id='"+this.prefix+"_response_img_"+i+"' src='"+responseValueConfig.img+"'/><br/>";
       }
-    }    
-  }
-    
-    if (this.callback) {
-      this.callback(this.prefix);      
+      var element = $("<input type='radio' data-mini='false' value='"+responseValueConfig.value+"' name='"+this.prefix+"_response' id='"+this.prefix+"_response_"+i+"'/> \
+        <label for='"+this.prefix+"_response_"+i+"'><center>"+img+""+responseValueConfig.label+"</center></label> \
+      ");
+      this.elements[this.elements.length] = element;
+      this.group.append(element);
     }
-  }).bind(this));
+
+    this.group.change((function() {
+
+      var set = false;
+      for (i = 0; i < this.elements.length; ++i) {
+        if (set === true) {
+          $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].img);
+        } else {
+          if ($("#"+this.prefix+"_response_"+i+":checked").val()) {
+            set = true;
+            $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].imgSelected);
+          } else {
+            $("#"+this.prefix+"_response_img_"+i).attr("src", this.responseConfig[i].imgHigherResponseSelected);
+          }
+        }
+      }
+
+      if (this.callback) {
+        this.callback(this.prefix);
+      }
+    }).bind(this));
   }
-    if (this.initDisabled) {
+  if (this.initDisabled) {
     this.group.children().attr('disabled', 'disabled');    
   }
   

--- a/lib/webmushra/misc/WaveformVisualizer.js
+++ b/lib/webmushra/misc/WaveformVisualizer.js
@@ -226,18 +226,18 @@ WaveformVisualizer.prototype.create = function(){
       var newRegion = this.calculateRegion(event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft);
     } 
     if(this.enableLooping){
-       if(this.leftRegionPosition != newRegion.left){
-          this.mushraAudioControl.setLoopStart(parseInt(newRegion.left/this.scale));
-        }else if(this.rightRegionPosition != newRegion.right){
-          this.mushraAudioControl.setLoopEnd(parseInt(newRegion.right/this.scale + newRegion.left / this.scale)); 
-        }
-     }else{
-       if(this.leftRegionPosition != newRegion.left){
-          this.mushraAudioControl.setPosition(parseInt(newRegion.left/this.scale)) 
-        }else if(this.rightRegionPosition != newRegion.right){
-          this.mushraAudioControl.setPosition(parseInt(newRegion.right/this.scale + newRegion.left/this.scale))
-        }     
-     }
+      if(this.leftRegionPosition != newRegion.left){
+        this.mushraAudioControl.setLoopStart(parseInt(newRegion.left/this.scale));
+      }else if(this.rightRegionPosition != newRegion.right){
+        this.mushraAudioControl.setLoopEnd(parseInt(newRegion.right/this.scale + newRegion.left / this.scale)); 
+      }
+    }else{
+      if(this.leftRegionPosition != newRegion.left){
+        this.mushraAudioControl.setPosition(parseInt(newRegion.left/this.scale)) 
+      }else if(this.rightRegionPosition != newRegion.right){
+        this.mushraAudioControl.setPosition(parseInt(newRegion.right/this.scale + newRegion.left/this.scale))
+      }     
+    }
   }).bind(this));
    
   this.refresh();

--- a/lib/webmushra/nls/nls.js
+++ b/lib/webmushra/nls/nls.js
@@ -8,7 +8,7 @@ nls['en']['previousButton'] = "Previous";
 nls['en']['playButton'] = "Play";
 nls['en']['stopButton'] = "Stop"; 
 nls['en']['pauseButton'] = "Pause";
-nls['en']['sendButton'] = "send Results";
+nls['en']['sendButton'] = "Send Results";
 
 nls['de']['nextButton'] = "Nächste Seite";
 nls['de']['previousButton'] = "Vorherige Seite"; 
@@ -87,6 +87,6 @@ nls['fr']['quest'] = "Quel item est la référence?";
 nls['en']['results'] = "Your results:";
 nls['de']['results'] = "Die Ergebnisse:";
 nls['fr']['results'] = "Vos résultats:";
-nls['en']['attending'] = "Thank you for attending!";
+nls['en']['attending'] = "Thank you for your participation!";
 nls['de']['attending'] = "Vielen Dank für die Teilnahme!";
 nls['fr']['attending'] = "Merci pour votre participation!";

--- a/lib/webmushra/pages/FinishPage.js
+++ b/lib/webmushra/pages/FinishPage.js
@@ -33,17 +33,17 @@ FinishPage.prototype.getName = function () {
 };
 
 FinishPage.prototype.storeParticipantData = function() {
-	var i;
-	for (i = 0; i < this.pageConfig.questionnaire.length; ++i) {
+  var i;
+  for (i = 0; i < this.pageConfig.questionnaire.length; ++i) {
       var element = this.pageConfig.questionnaire[i];
      
       this.session.participant.name[this.session.participant.name.length] = element.name;
       if($("#" + element.name).val()){
         this.session.participant.response[this.session.participant.response.length] = $("#" + element.name).val(); 
-	  } else { 
+    } else { 
       this.session.participant.response[this.session.participant.response.length] = $("input[name='"+element.name + "__response']:checked").val();
-	  }
- 	}
+    }
+   }
 };
 
 FinishPage.prototype.sendResults = function() {
@@ -64,13 +64,10 @@ FinishPage.prototype.render = function (_parent) {
     for (i = 0; i < this.pageConfig.questionnaire.length; ++i) {
       var element = this.pageConfig.questionnaire[i];
       if (element.type === "text") {
-      	     	
         table.append($("<tr><td><strong>"+ element.label +"</strong></td><td><input id='"+element.name+"' /></td></tr>"));
       } else if (element.type === "number") {
-                
         table.append($("<tr><td><strong>"+ element.label +"</strong></td><td><input id='"+element.name+"' min='"+element.min+"' max='"+element.max+"' value='"+element.default+"' data-inline='true'/></td></tr>"));
       } else if(element.type === "likert") {
-                
         this.likert = new LikertScale(element.response, element.name + "_");
         var td = $("<td></td>");
         table.append($("<tr></tr>").append(
@@ -79,7 +76,6 @@ FinishPage.prototype.render = function (_parent) {
         ));
         this.likert.render(td);        
       }else if (element.type === "long_text"){
-        
         table.append($("<tr><td id='labeltd' style='vertical-align:top; padding-top:"+ $('#feedback').css('margin-top') +"'><strong>"+ element.label +"</strong></td><td><textarea name='"+element.name+"' id='"+element.name+"'></textarea></td></tr>"));      
       }
       console.log(element);    
@@ -119,140 +115,139 @@ FinishPage.prototype.render = function (_parent) {
       for (i = 0; i < trials.length; ++i) {
         var trial = trials[i];
         if (trial.type === "mushra") {
-	        trT = document.createElement("tr");        
-	        thT = $("<th colspan='2'></th>");
-	        $(thT).append(trial.id + " (MUSHRA)" );
-	        $(trT).append(thT);
-	        $(table).append(trT);
-	
-	        var ratings = trial.responses;
-	        for (var j = 0; j < ratings.length; ++j) {
-	          trRatings = document.createElement("tr");
-	          tdRatingStimulus = document.createElement("td");
-	          tdRatingScore = document.createElement("td");
-	
-	          tdRatingStimulus.width = "50%";
-	          tdRatingScore.width = "50%";
-	
-	          var rating = ratings[j];
-	
-	          $(tdRatingStimulus).append(rating.stimulus + ": ");
-	          $(tdRatingScore).append(rating.score);
-	          $(trRatings).append(tdRatingStimulus);
-	          $(trRatings).append(tdRatingScore);
-	          $(table).append(trRatings);
- 	          
-	        }
-	        trEmpty = $("<tr height='8px'></tr>");
-	     		$(table).append(trEmpty);
-	     } else if (trial.type === "paired_comparison") {
-	     	
-	     	trPaired = document.createElement("tr"); 
-	     	thT = $("<th colspan='2'></th>");
-	     	$(thT).append(trial.id + " (Paired Comparison)" );
-	     	$(trPaired).append(thT);
-	     	$(table).append(trPaired);
-	     	var j;
-	     	for(j = 0; j < trial.responses.length; ++j){
-	     		trPC = document.createElement("tr"); 
-	     		tdPCReference = document.createElement("td"); 
-	     		tdPCres = document.createElement("td");
-	     		
-	     		var response = trial.responses[j];
-	     		
-	     		
-	     		$(tdPCres).append(response.answer);
-	     		$(tdPCReference).append(response.nonReference);
-	     		$(trPC).append(tdPCReference);
-	     		$(trPC).append(tdPCres); 
-	     		$(table).append(trPC);
-	     	}
-	     	 trEmpty = $("<tr height='8px'></tr>");
-	     		$(table).append(trEmpty);
-	     	
-	     } else if(trial.type ==="bs1116") {
-	     	trPaired = document.createElement("tr"); 
-	     	thT = $("<th colspan='2'></th>");
-	     	$(thT).append(trial.id + " (BS1116)" );
-	     	$(trPaired).append(thT);
-	     	$(table).append(trPaired);
-	     	
-	     	var j;
-	     	for(j = 0; j < trial.responses.length; ++j){
-	     		var response = trial.responses[j];
-	     		
-	     		
-	     		trBS1 = document.createElement("tr"); 
-	     		trBS2 = document.createElement("tr");
-	     		tdBSReference = document.createElement("td"); 
-	     		tdBSRefValue = document.createElement("td"); 
-	     		tdBSCondition = document.createElement("td");
-	     		tdBSConValue = document.createElement("td");
-	     		
-	     		$(tdBSReference).append(response.reference + ": ");
-	     		$(tdBSRefValue).append(response.referenceScore);
-	     		$(trBS1).append(tdBSReference);
-	     		$(trBS1).append(tdBSRefValue);
-	     		
-	     		$(tdBSCondition).append(response.nonReference + ": ");
-	     		$(tdBSConValue).append(response.nonReferenceScore);
-	     		$(trBS2).append(tdBSCondition);
-	     		$(trBS2).append(tdBSConValue);
-	     		
-	     		trEmpty = $("<tr height='5px'></tr>");
+          trT = document.createElement("tr");        
+          thT = $("<th colspan='2'></th>");
+          $(thT).append(trial.id + " (MUSHRA)" );
+          $(trT).append(thT);
+          $(table).append(trT);
+  
+          var ratings = trial.responses;
+          for (var j = 0; j < ratings.length; ++j) {
+            trRatings = document.createElement("tr");
+            tdRatingStimulus = document.createElement("td");
+            tdRatingScore = document.createElement("td");
+  
+            tdRatingStimulus.width = "50%";
+            tdRatingScore.width = "50%";
+  
+            var rating = ratings[j];
+  
+            $(tdRatingStimulus).append(rating.stimulus + ": ");
+            $(tdRatingScore).append(rating.score);
+            $(trRatings).append(tdRatingStimulus);
+            $(trRatings).append(tdRatingScore);
+            $(table).append(trRatings);
+             
+          }
+          trEmpty = $("<tr height='8px'></tr>");
+          $(table).append(trEmpty);
+        } else if (trial.type === "paired_comparison") {
+          
+          trPaired = document.createElement("tr"); 
+          thT = $("<th colspan='2'></th>");
+          $(thT).append(trial.id + " (Paired Comparison)" );
+          $(trPaired).append(thT);
+          $(table).append(trPaired);
+          var j;
+          for(j = 0; j < trial.responses.length; ++j){
+            trPC = document.createElement("tr"); 
+            tdPCReference = document.createElement("td"); 
+            tdPCres = document.createElement("td");
+            
+            var response = trial.responses[j];
+            
+            
+            $(tdPCres).append(response.answer);
+            $(tdPCReference).append(response.nonReference);
+            $(trPC).append(tdPCReference);
+            $(trPC).append(tdPCres); 
+            $(table).append(trPC);
+          }
+          trEmpty = $("<tr height='8px'></tr>");
+            $(table).append(trEmpty);
+         
+        } else if(trial.type ==="bs1116") {
+          trPaired = document.createElement("tr"); 
+          thT = $("<th colspan='2'></th>");
+          $(thT).append(trial.id + " (BS1116)" );
+          $(trPaired).append(thT);
+          $(table).append(trPaired);
+          
+          var j;
+          for(j = 0; j < trial.responses.length; ++j){
+            var response = trial.responses[j];
+            
+            
+            trBS1 = document.createElement("tr"); 
+            trBS2 = document.createElement("tr");
+            tdBSReference = document.createElement("td"); 
+            tdBSRefValue = document.createElement("td"); 
+            tdBSCondition = document.createElement("td");
+            tdBSConValue = document.createElement("td");
+            
+            $(tdBSReference).append(response.reference + ": ");
+            $(tdBSRefValue).append(response.referenceScore);
+            $(trBS1).append(tdBSReference);
+            $(trBS1).append(tdBSRefValue);
+            
+            $(tdBSCondition).append(response.nonReference + ": ");
+            $(tdBSConValue).append(response.nonReferenceScore);
+            $(trBS2).append(tdBSCondition);
+            $(trBS2).append(tdBSConValue);
+            
+            trEmpty = $("<tr height='5px'></tr>");
 
-	     		$(table).append(trBS1);
-	     		$(table).append(trBS2);
-				$(table).append(trEmpty);
-	     	}
-	     	trEmpty = $("<tr height='3px'></tr>");
-	     	$(table).append(trEmpty);
-	     } else if( trial.type === "likert_multi_stimulus"){
-	     	trLMSH = document.createElement("tr"); 
-	     	thT = $("<th colspan='2'></th>");
-	     	$(thT).append(trial.id + " (LMS)" );
-	     	$(trLMSH).append(thT);
-	     	$(table).append(trLMSH);
-	     	var j;
-	     	for(j = 0; j < trial.responses.length; ++j){
-	     		trLMS = document.createElement("tr");
-	     		
-	     		tdStimulus = document.createElement("td");
-	     		tdRating = document.createElement("td");
-	     		
-	     		$(tdStimulus).append(trial.responses[j].stimulus + ": ");
-	     		$(tdRating).append(trial.responses[j].stimulusRating);
-	     		
-	     		$(trLMS).append(tdStimulus);
-	     		$(trLMS).append(tdRating);
-	     		
-	     		$(table).append(trLMS);
-	     		
-	     	}
-     	} else if(trial.type === "likert_single_stimulus"){
-     		trLSSH = document.createElement("tr"); 
-	     	thT = $("<th colspan='2'></th>");
-	     	$(thT).append(trial.id + " (LSS)" );
-	     	$(trLSSH).append(thT);
-	     	$(table).append(trLSSH);
-	     	
-	     	var j;
-	     	for(j = 0; j < trial.responses.length; ++j){
-	     		trLSS = document.createElement("tr");
-	     		
-	     		tdStimuli = document.createElement("td");
-	     		tdRating = document.createElement("td");
-	     		
-	     		$(tdStimuli).append(trial.responses[j].stimulus + ": ");
-	     		$(tdRating).append(trial.responses[j].stimulusRating);
-	     		
-	     		$(trLSS).append(tdStimuli);
-	     		$(trLSS).append(tdRating);
-	     		
-	     		$(table).append(trLSS);
-	     	}
-	     }
-	    
+            $(table).append(trBS1);
+            $(table).append(trBS2);
+            $(table).append(trEmpty);
+          }
+          trEmpty = $("<tr height='3px'></tr>");
+          $(table).append(trEmpty);
+        } else if( trial.type === "likert_multi_stimulus"){
+          trLMSH = document.createElement("tr"); 
+          thT = $("<th colspan='2'></th>");
+          $(thT).append(trial.id + " (LMS)" );
+          $(trLMSH).append(thT);
+          $(table).append(trLMSH);
+          var j;
+          for(j = 0; j < trial.responses.length; ++j){
+            trLMS = document.createElement("tr");
+            
+            tdStimulus = document.createElement("td");
+            tdRating = document.createElement("td");
+            
+            $(tdStimulus).append(trial.responses[j].stimulus + ": ");
+            $(tdRating).append(trial.responses[j].stimulusRating);
+            
+            $(trLMS).append(tdStimulus);
+            $(trLMS).append(tdRating);
+            
+            $(table).append(trLMS);
+            
+          }
+        } else if(trial.type === "likert_single_stimulus"){
+          trLSSH = document.createElement("tr"); 
+          thT = $("<th colspan='2'></th>");
+          $(thT).append(trial.id + " (LSS)" );
+          $(trLSSH).append(thT);
+          $(table).append(trLSSH);
+          
+          var j;
+          for(j = 0; j < trial.responses.length; ++j){
+            trLSS = document.createElement("tr");
+            
+            tdStimuli = document.createElement("td");
+            tdRating = document.createElement("td");
+            
+            $(tdStimuli).append(trial.responses[j].stimulus + ": ");
+            $(tdRating).append(trial.responses[j].stimulusRating);
+            
+            $(trLSS).append(tdStimuli);
+            $(trLSS).append(tdRating);
+            
+            $(table).append(trLSS);
+          }
+        }
       }
      }
 
@@ -292,7 +287,7 @@ FinishPage.prototype.load = function() {
         if (counter == this.pageConfig.questionnaire.length) {
           $('#send_results').removeAttr('disabled');
         } else if( i +1 == this.pageConfig.questionnaire.length && counter != this.pageConfig.questionnaire.length && $('#send_results').is(':enabled')){
-        	$('#send_results').attr('disabled', true);       	
+          $('#send_results').attr('disabled', true);
         }
       }
     }).

--- a/lib/webmushra/pages/FinishPage.js
+++ b/lib/webmushra/pages/FinishPage.js
@@ -240,7 +240,11 @@ FinishPage.prototype.render = function (_parent) {
             tdRating = document.createElement("td");
             
             $(tdStimuli).append(trial.responses[j].stimulus + ": ");
-            $(tdRating).append(trial.responses[j].stimulusRating);
+            var allRatings = trial.responses[j].stimulusRating[0];
+            for(var k = 1; k < trial.responses[j].stimulusRating.length; ++k){
+              allRatings += ', ' + trial.responses[j].stimulusRating[k];
+            }
+            $(tdRating).append(allRatings);
             
             $(trLSS).append(tdStimuli);
             $(trLSS).append(tdRating);

--- a/lib/webmushra/pages/LikertMultiStimulusPage.js
+++ b/lib/webmushra/pages/LikertMultiStimulusPage.js
@@ -60,12 +60,12 @@ LikertMultiStimulusPage.prototype.init = function (_callbackError) {
   }
   
   for (var i = 0; i < this.stimuli.length; ++i) {    
-    this.likerts[i] = new LikertScale(this.pageConfig.response, i + "_", this.pageConfig.mustPlayback == true, cbk);
+    this.likerts[i] = new LikertScale(this.pageConfig.response, i + "_", this.pageConfig.mustPlayback, cbk);
   }
   this.filePlayer = new FilePlayer(this.audioContext, this.bufferSize, this.stimuli, this.errorHandler, this.language, this.pageManager.getLocalizer());
   if (this.pageConfig.mustPlayback) {
     this.filePlayer.genericAudioControl.addEventListener((function (_event) {
-      if (_event.name == 'ended') {
+      if (_event.name == this.pageConfig.mustPlayback) {
         this.likerts[_event.index].enable();
       } 
     }).bind(this));

--- a/lib/webmushra/pages/LikertSingleStimulusPage.js
+++ b/lib/webmushra/pages/LikertSingleStimulusPage.js
@@ -20,12 +20,12 @@ function LikertSingleStimulusPage(_pageManager, _pageTemplateRenderer, _pageConf
     
   this.audioFileLoader.addFile(this.stimulus.getFilepath(), (function (_buffer, _stimulus) { _stimulus.setAudioBuffer(_buffer); }), this.stimulus);
   this.filePlayer = null;
-  this.likert = null;
-  this.ratingMap = new Array();
+  this.likerts = [];
+  this.ratingMap = {};
     
   this.time = 0; 
   this.startTimeOnPage = null;
-  this.result= null;
+  this.results= [];
 } 
 
 LikertSingleStimulusPage.prototype.getName = function () {
@@ -37,7 +37,7 @@ LikertSingleStimulusPage.prototype.init = function (_callbackError) {
   
   var cbk = (function(_prefix) {
     this.ratingMap[_prefix] = true;
-    if (Object.keys(this.ratingMap).length == 1) {
+    if (Object.keys(this.ratingMap).length == this.likerts.length) {
       this.pageTemplateRenderer.unlockNextButton();
     }
   }).bind(this);
@@ -47,14 +47,18 @@ LikertSingleStimulusPage.prototype.init = function (_callbackError) {
     cbk = false;  
   }
   
-  
-  this.likert = new LikertScale(this.pageConfig.response, "1_", this.pageConfig.mustPlayback, cbk);
- 
+  if (Array.isArray(this.pageConfig.response[0])) {
+    for (var i = 0; i < this.pageConfig.response.length; ++i) {
+      this.likerts.push(new LikertScale(this.pageConfig.response[i], i + '_', this.pageConfig.mustPlayback, cbk));
+    }
+  } else {
+    this.likerts.push(new LikertScale(this.pageConfig.response, '1_', this.pageConfig.mustPlayback, cbk));
+  }
  
   if (this.pageConfig.mustPlayback) {
     this.filePlayer.genericAudioControl.addEventListener((function (_event) {
       if (_event.name == this.pageConfig.mustPlayback) {
-        this.likert.enable();
+        this.likerts.map(function(l) {l.enable();});
       } 
     }).bind(this));
 
@@ -82,7 +86,7 @@ LikertSingleStimulusPage.prototype.render = function (_parent) {
   this.filePlayer.render(_parent);
 
   
-  this.likert.render(_parent); 
+  this.likerts.map(function(l) {l.render(_parent);});
   
   this.fpc = new FilePlayerController(this.filePlayer);
   this.fpc.bind();
@@ -93,10 +97,12 @@ LikertSingleStimulusPage.prototype.load = function () {
   if(this.pageConfig.mustRate == true){
     this.pageTemplateRenderer.lockNextButton();
   }
-  if(this.result){
-    $("input[name='"+this.likert.prefix +"_response'][value='"+this.result+"']").attr("checked", "checked");
-    $("input[name='"+this.likert.prefix +"_response'][value='"+this.result+"']").checkboxradio("refresh");
-    this.likert.group.change();
+  if(this.results.length > 0){
+    for (var i = 0; i < this.likerts.length; ++i) {
+      $("input[name='"+this.likerts[i].prefix +"_response'][value='"+this.results[i]+"']").attr("checked", "checked");
+      $("input[name='"+this.likerts[i].prefix +"_response'][value='"+this.results[i]+"']").checkboxradio("refresh");
+      this.likerts[i].group.change();
+    }
   }
   
   this.filePlayer.init();
@@ -106,7 +112,9 @@ LikertSingleStimulusPage.prototype.save = function () {
   this.fpc.unbind(); 
   this.time += (new Date() - this.startTimeOnPage);
   
-  this.result = $("input[name='"+this.likert.prefix +"_response']:checked").val();
+  for (var i = 0; i < this.likerts.length; ++i) {
+    this.results[i] = $("input[name='"+this.likerts[i].prefix +"_response']:checked").val();
+  }
   
   this.filePlayer.free();
 };
@@ -122,10 +130,13 @@ LikertSingleStimulusPage.prototype.store = function (_reponsesStorage) {
   var rating = new LikertSingleStimulusRating();
   rating.stimulus = this.stimulus.id;
   
-  if(this.result == undefined){
-    rating.stimulusRating = "NA";
-  }else{
-    rating.stimulusRating = this.result;
+  rating.stimulusRating = [];
+  for(var i = 0; i < this.likerts.length; ++i){
+    if(this.results[i] === undefined){
+      rating.stimulusRating.push("NA");
+    }else{
+      rating.stimulusRating.push(this.results[i]);
+    }
   }
       
   rating.time = this.time;

--- a/lib/webmushra/pages/LikertSingleStimulusPage.js
+++ b/lib/webmushra/pages/LikertSingleStimulusPage.js
@@ -20,6 +20,7 @@ function LikertSingleStimulusPage(_pageManager, _pageTemplateRenderer, _pageConf
     
   this.audioFileLoader.addFile(this.stimulus.getFilepath(), (function (_buffer, _stimulus) { _stimulus.setAudioBuffer(_buffer); }), this.stimulus);
   this.filePlayer = null;
+  this.waveformVisualizer = null;
   this.likerts = [];
   this.ratingMap = {};
     
@@ -33,7 +34,7 @@ LikertSingleStimulusPage.prototype.getName = function () {
 };
 
 LikertSingleStimulusPage.prototype.init = function (_callbackError) { 
-  this.filePlayer = new FilePlayer(this.audioContext, this.bufferSize, [this.stimulus], this.errorHandler, this.language, this.pageManager.getLocalizer());
+  this.filePlayer = new FilePlayer(this.audioContext, this.bufferSize, [this.stimulus], this.errorHandler, this.language, this.pageManager.getLocalizer(), this.pageConfig.showWaveform);
   
   var cbk = (function(_prefix) {
     this.ratingMap[_prefix] = true;
@@ -83,6 +84,14 @@ LikertSingleStimulusPage.prototype.render = function (_parent) {
   var p = $("<p>" + content + "</p>");
   div.append(p);
       
+  if (this.pageConfig.showWaveform === true) {
+    var waveform = $("<p></p>");
+    div.append(waveform);
+    
+    this.waveformVisualizer = new WaveformVisualizer(this.pageManager.getPageVariableName(this) + ".waveformVisualizer", waveform, this.stimulus, this.pageConfig.showWaveform, false, this.filePlayer.genericAudioControl);
+    this.waveformVisualizer.create();
+    this.waveformVisualizer.load();
+  }
   this.filePlayer.render(_parent);
 
   

--- a/lib/webmushra/pages/LikertSingleStimulusPage.js
+++ b/lib/webmushra/pages/LikertSingleStimulusPage.js
@@ -35,7 +35,7 @@ LikertSingleStimulusPage.prototype.getName = function () {
 LikertSingleStimulusPage.prototype.init = function (_callbackError) { 
   this.filePlayer = new FilePlayer(this.audioContext, this.bufferSize, [this.stimulus], this.errorHandler, this.language, this.pageManager.getLocalizer());
   
-    var cbk = (function(_prefix) {
+  var cbk = (function(_prefix) {
     this.ratingMap[_prefix] = true;
     if (Object.keys(this.ratingMap).length == 1) {
       this.pageTemplateRenderer.unlockNextButton();
@@ -48,7 +48,7 @@ LikertSingleStimulusPage.prototype.init = function (_callbackError) {
   }
   
   
-    this.likert = new LikertScale(this.pageConfig.response, "1_", this.pageConfig.mustPlayback == true, cbk);
+  this.likert = new LikertScale(this.pageConfig.response, "1_", this.pageConfig.mustPlayback == true, cbk);
  
  
   if (this.pageConfig.mustPlayback) {
@@ -58,7 +58,7 @@ LikertSingleStimulusPage.prototype.init = function (_callbackError) {
       } 
     }).bind(this));
 
-	}
+  }
 
 };
   
@@ -93,10 +93,10 @@ LikertSingleStimulusPage.prototype.load = function () {
   if(this.pageConfig.mustRate == true){
     this.pageTemplateRenderer.lockNextButton();
   }
-	if(this.result){
+  if(this.result){
     $("input[name='"+this.likert.prefix +"_response'][value='"+this.result+"']").attr("checked", "checked");
     $("input[name='"+this.likert.prefix +"_response'][value='"+this.result+"']").checkboxradio("refresh");
-    this.likert.group.change();  
+    this.likert.group.change();
   }
   
   this.filePlayer.init();
@@ -112,15 +112,12 @@ LikertSingleStimulusPage.prototype.save = function () {
 };
 
 LikertSingleStimulusPage.prototype.store = function (_reponsesStorage) {
-		
-	
-	
   var trial = this.session.getTrial(this.pageConfig.type, this.pageConfig.id);
   if (trial === null) {
     trial = new Trial();
-	trial.type = this.pageConfig.type;
-	trial.id = this.pageConfig.id;
-	this.session.trials[this.session.trials.length] = trial;	  
+    trial.type = this.pageConfig.type;
+    trial.id = this.pageConfig.id;
+    this.session.trials[this.session.trials.length] = trial;
   }
   var rating = new LikertSingleStimulusRating();
   rating.stimulus = this.stimulus.id;
@@ -130,7 +127,7 @@ LikertSingleStimulusPage.prototype.store = function (_reponsesStorage) {
   }else{
     rating.stimulusRating = this.result;
   }
-    
+      
   rating.time = this.time;
   trial.responses[trial.responses.length] = rating;
 

--- a/lib/webmushra/pages/LikertSingleStimulusPage.js
+++ b/lib/webmushra/pages/LikertSingleStimulusPage.js
@@ -48,12 +48,12 @@ LikertSingleStimulusPage.prototype.init = function (_callbackError) {
   }
   
   
-  this.likert = new LikertScale(this.pageConfig.response, "1_", this.pageConfig.mustPlayback == true, cbk);
+  this.likert = new LikertScale(this.pageConfig.response, "1_", this.pageConfig.mustPlayback, cbk);
  
  
   if (this.pageConfig.mustPlayback) {
     this.filePlayer.genericAudioControl.addEventListener((function (_event) {
-      if (_event.name == 'ended') {
+      if (_event.name == this.pageConfig.mustPlayback) {
         this.likert.enable();
       } 
     }).bind(this));

--- a/lib/webmushra/pages/LikertSingleStimulusPageManager.js
+++ b/lib/webmushra/pages/LikertSingleStimulusPageManager.js
@@ -16,7 +16,11 @@ LikertSingleStimulusPageManager.prototype.createPages = function (_pageManager, 
   }
   shuffle(this.stimuli);
   
-  for (var i = 0; i < this.stimuli.length; ++i) {    
+  var numStimuli = this.stimuli.length;
+  if (_pageConfig.maxStimuli > 0) {
+    numStimuli = Math.min(numStimuli, _pageConfig.maxStimuli);
+  }
+  for (var i = 0; i < numStimuli; ++i) {    
     var page = new LikertSingleStimulusPage(_pageManager, pageTemplateRenderer, _pageConfig, _audioContext, _bufferSize, _audioFileLoader, this.stimuli[i], _session, _errorHandler, _language);
     _pageManager.addPage(page);
   }  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webMUSHRA",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/service/write.php
+++ b/service/write.php
@@ -236,7 +236,16 @@ $input = array("session_test_id");
 for($i =0; $i < $length; $i++){
 	array_push($input, $session->participant->name[$i]);
 }
-array_push($input,  "trial_id", "stimuli_rating", "stimuli", "rating_time");
+array_push($input,  "trial_id");
+$ratingCount = count($session->trials[0]->responses[0]->stimulusRating);
+if($ratingCount > 1) {
+    for($i =0; $i < $ratingCount; $i++){
+        array_push($input, "stimuli_rating" . ($i+1));
+    }
+} else {
+    array_push($input, "stimuli_rating");
+}
+array_push($input, "stimuli", "rating_time");
 array_push($lssCSVdata, $input);
 
 foreach($session->trials as $trial) {
@@ -248,8 +257,10 @@ foreach($session->trials as $trial) {
 				$results = array($session->testId);
 			for($i =0; $i < $length; $i++){
 				array_push($results, $session->participant->response[$i]);
-			}  
-			array_push($results,  $trial->id, " $response->stimulusRating ", $response->stimulus, $response->time);
+			}
+            array_push($results, $trial->id);
+            $results = array_merge($results, $response->stimulusRating);
+            array_push($results, $response->stimulus, $response->time);
 		  
 		  	array_push($lssCSVdata, $results); 
 			


### PR DESCRIPTION
Four new features added to Likert stimulus pages:

- allow multiple Likert scales on Single Stimulus pages
- add config option to require playback to start before rating gets enabled (the option to enforce playback to complete before rating gets enabled already exists)
- add option to display waveform on Likert Single Stimulus pages
- add option to limit number of (randomised) stimuli presented to user to Likert Single Stimulus pages

preceded by various minor fixes
