### PR TITLE
Added a version check around get_magic_quotes_gpc() 

### DIFF
--- a/service/write.php
+++ b/service/write.php
@@ -18,11 +18,15 @@ function sanitize($string = '', $is_filename = FALSE)
 
 
 $sessionParam = null;
-if(get_magic_quotes_gpc()){
-  $sessionParam = stripslashes($_POST['sessionJSON']);
+
+//get_magic_quotes_gpc() was removed in PHP 8
+if(version_compare(PHP_VERSION, '8.0.0', '<') and get_magic_quotes_gpc()){
+	$sessionParam = stripslashes($_POST['sessionJSON']);
 }else{
-  $sessionParam = $_POST['sessionJSON'];
+	$sessionParam = $_POST['sessionJSON'];
 }
+
+
 $session = json_decode($sessionParam);
 
 


### PR DESCRIPTION
The function get_magic_quotes_gpc() was removed in PHP 8.0 so the results won't be written if PHP 8 or above is used (see #60 ). I added a version check so that the function is only used for PHP <8.0. Tested successfully on a  fresh install of XAMPP, which ships with PHP 8.0.
