### PR TITLE
enable switchBack option

### DIFF
--- a/doc/experimenter.md
+++ b/doc/experimenter.md
@@ -65,7 +65,7 @@ A mushra page shows a trial according to ITU-R Recommendation BS.1534.
 * **randomize** If set to true, the conditions are randomized.
 * **showConditionNames** If set to true, the names of the conditions are shown.
 * **stimuli** A map of stimuli representing three conditions. The key is the name of the condition. The value is the filepath to the stimulus (WAV file).  
-
+* **switchBack** If set to true, the time position is set back to the beginning (sample 0) when switching between test conditions and/or the reference. By default, this option is false.
 
 #### `bs1116` page          
 

--- a/lib/webmushra/audio/MushraAudioControl.js
+++ b/lib/webmushra/audio/MushraAudioControl.js
@@ -5,7 +5,7 @@ This source code is protected by copyright law and international treaties. This 
 
 **************************************************************************/
 
-function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions, _errorHandler, _createAnchor35, _createAnchor70, _randomize) {
+function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions, _errorHandler, _createAnchor35, _createAnchor70, _randomize, _switchBack) {
   this.audioContext = _audioContext;
   this.bufferSize = parseInt(_bufferSize);
   this.reference = _reference;
@@ -13,6 +13,7 @@ function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions,
   this.errorHandler = _errorHandler;
   this.createAnchor35 = _createAnchor35;
   this.createAnchor70 = _createAnchor70;
+  this.switchBack = _switchBack;
   this.lowAnchor = null;
   this.midAnchor = null;
   
@@ -417,6 +418,9 @@ MushraAudioControl.prototype.getActiveStimulus = function() {
 
 MushraAudioControl.prototype.playReference = function() {
   this.play(this.reference, true);
+  if (this.switchBack) {
+    this.setPosition(0, false);
+  };
   this.audioIsReferencePlaying = true;
 
   
@@ -430,7 +434,10 @@ MushraAudioControl.prototype.playReference = function() {
 };
 
 MushraAudioControl.prototype.playCondition = function(_index) {
-  this.play(this.conditions[_index], false);  
+  this.play(this.conditions[_index], false);
+  if (this.switchBack) {
+    this.setPosition(0, false);
+  };
   this.audioIsReferencePlaying = false;
   var event = {
   	name: 'playConditionTriggered',

--- a/lib/webmushra/pages/MushraPage.js
+++ b/lib/webmushra/pages/MushraPage.js
@@ -67,9 +67,7 @@ MushraPage.prototype.init = function () {
   }
   this.mushraValidator.checkConditionConsistency(this.reference, this.conditions);
 
-
-
-  this.mushraAudioControl = new MushraAudioControl(this.audioContext, this.bufferSize, this.reference, this.conditions, this.errorHandler, this.pageConfig.createAnchor35, this.pageConfig.createAnchor70, this.pageConfig.randomize);
+  this.mushraAudioControl = new MushraAudioControl(this.audioContext, this.bufferSize, this.reference, this.conditions, this.errorHandler, this.pageConfig.createAnchor35, this.pageConfig.createAnchor70, this.pageConfig.randomize, this.pageConfig.switchBack);
   this.mushraAudioControl.addEventListener((function (_event) {
   if (_event.name == 'stopTriggered') {
     $(".audioControlElement").text(this.pageManager.getLocalizer().getFragment(this.language, 'playButton'));


### PR DESCRIPTION
This PR enables a `switchBack` option for MUSHRA pages, where the time position in the audio file is set to 0 when switching between conditions and/or the reference. Even though this behavior is not recommended in general, it may be better to have this in certain situations.