### PR TITLE
make inclusion of reference as condition optional in mushra tests

### DIFF
--- a/lib/webmushra/audio/MushraAudioControl.js
+++ b/lib/webmushra/audio/MushraAudioControl.js
@@ -5,12 +5,13 @@ This source code is protected by copyright law and international treaties. This 
 
 **************************************************************************/
 
-function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions, _errorHandler, _createAnchor35, _createAnchor70, _randomize, _switchBack) {
+function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions, _errorHandler, _excludeReferenceFromConditions, _createAnchor35, _createAnchor70, _randomize, _switchBack) {
   this.audioContext = _audioContext;
   this.bufferSize = parseInt(_bufferSize);
   this.reference = _reference;
   this.conditions = _conditions;    
   this.errorHandler = _errorHandler;
+  this.excludeReferenceFromConditions = _excludeReferenceFromConditions;
   this.createAnchor35 = _createAnchor35;
   this.createAnchor70 = _createAnchor70;
   this.switchBack = _switchBack;
@@ -41,7 +42,10 @@ function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions,
   //listeners
   this.eventListeners = [];
 
-  this.conditions[this.conditions.length] = this.reference;  
+  // include or exclude reference from conditions
+  if (this.excludeReferenceFromConditions === false) {  // default is false
+    this.conditions[this.conditions.length] = this.reference;
+  }
   
   // add anchors
   if (this.createAnchor35) {

--- a/lib/webmushra/pages/MushraPage.js
+++ b/lib/webmushra/pages/MushraPage.js
@@ -67,7 +67,7 @@ MushraPage.prototype.init = function () {
   }
   this.mushraValidator.checkConditionConsistency(this.reference, this.conditions);
 
-  this.mushraAudioControl = new MushraAudioControl(this.audioContext, this.bufferSize, this.reference, this.conditions, this.errorHandler, this.pageConfig.createAnchor35, this.pageConfig.createAnchor70, this.pageConfig.randomize, this.pageConfig.switchBack);
+  this.mushraAudioControl = new MushraAudioControl(this.audioContext, this.bufferSize, this.reference, this.conditions, this.errorHandler, this.pageConfig.excludeReferenceFromConditions, this.pageConfig.createAnchor35, this.pageConfig.createAnchor70, this.pageConfig.randomize, this.pageConfig.switchBack);
   this.mushraAudioControl.addEventListener((function (_event) {
   if (_event.name == 'stopTriggered') {
     $(".audioControlElement").text(this.pageManager.getLocalizer().getFragment(this.language, 'playButton'));


### PR DESCRIPTION
by adding `excludeReferenceFromConditions` users can now optionally exclude the reference to be used as a condition in MUSHRA tests!